### PR TITLE
Added TAKEOWNERSHIP command to TorControlConnection.

### DIFF
--- a/net/freehaven/tor/control/TorControlConnection.java
+++ b/net/freehaven/tor/control/TorControlConnection.java
@@ -728,5 +728,12 @@ public class TorControlConnection implements TorControlCommands {
         sendAndWaitForResponse("CLOSECIRCUIT "+circID+
                                (ifUnused?" IFUNUSED":"")+"\r\n", null);
     }
+
+    /** Tells Tor to exit when this control connection is closed. This command
+     * was added in Tor 0.2.2.28-beta.
+     */
+    public void takeOwnership() throws IOException {
+        sendAndWaitForResponse("TAKEOWNERSHIP\r\n", null);
+    }
 }
 


### PR DESCRIPTION
This command tells Tor to exit when the control socket is closed. It can be used in combination with the __OwningControllerProcess config option to ensure that Tor exits when the controlling process exits. This has enabled us to remove a lot of zombie-hunting logic from Briar's Tor plugin.
