### PR TITLE
FORGETHS -> HSFORGET

### DIFF
--- a/net/freehaven/tor/control/TorControlConnection.java
+++ b/net/freehaven/tor/control/TorControlConnection.java
@@ -740,7 +740,7 @@ public class TorControlConnection implements TorControlCommands {
      * service with the given hostname (excluding the .onion extension).
      */
     public void forgetHiddenService(String hostname) throws IOException {
-        sendAndWaitForResponse("FORGETHS " + hostname + "\r\n", null);
+        sendAndWaitForResponse("HSFORGET " + hostname + "\r\n", null);
     }
 }
 


### PR DESCRIPTION
This updates the `forgetHiddenService()` method with the correct TorControl command.

The patch to Tor implementing `HSFORGET` is [being upstreamed, currently targeting 0.2.9](https://trac.torproject.org/projects/tor/ticket/18620).
